### PR TITLE
typo fix, clarification of Known Issues

### DIFF
--- a/Migrating.md
+++ b/Migrating.md
@@ -144,7 +144,7 @@ offending commit, have already been pushed to GitHub, updating the commit
 message on GitHub is not advised, as it would change the public history of the
 repository.  If you encounter this error you should fix the error message with
 `git commit --amend`, then `git push -f` to force push the commit and `git svn
-dcommit` to svn.  *Note doing this edits the public history, so if other users
+dcommit` to svn.  *Note doing this edits the public history, so other users'
 history may be out of sync!*
 
 ## Troubleshooting #


### PR DESCRIPTION
Fixed typo; I think there might also be a missing phrase, something along the lines that if some has `git svn rebase`d or `git fetch`d in the intervening time (before it's revised) their history may be out of sync.

Also, this paragraph could use clarification. It looks like it says don't push to the public repository because it'll mess up public history, but then gives instructions to push to the public repository. Maybe I'm missing a distinction in talking about the git public repository and the svn public repository?
